### PR TITLE
Added Try, Catch to prevent crash in metadata form

### DIFF
--- a/ClimsoftVer4/ClimsoftVer4/formMetadata.vb
+++ b/ClimsoftVer4/ClimsoftVer4/formMetadata.vb
@@ -35,10 +35,15 @@
 
     Sub SetDataSet(tbl As String)
         Dim sql As String
-        sql = "SELECT * FROM " & tbl
-        da = New MySql.Data.MySqlClient.MySqlDataAdapter(sql, dbconn)
-        da.Fill(ds, tbl)
-        Kount = ds.Tables(tbl).Rows.Count
+        Try
+            sql = "SELECT * FROM " & tbl
+            da = New MySql.Data.MySqlClient.MySqlDataAdapter(sql, dbconn)
+            da.Fill(ds, tbl)
+            Kount = ds.Tables(tbl).Rows.Count
+        Catch ex As Exception
+            MsgBox(ex.Message)
+        End Try
+
     End Sub
 
     Private Sub TabStation_Click(sender As Object, e As EventArgs) Handles TabStation.Click


### PR DESCRIPTION
Switching to the `Paper archive` tab in the metadata form causes Climsoft to crash if the paperarchive table is missing from the database.

@sawadogolazare has fixed this by wrapping the data adapter code in a `Try` ... `Catch` statement.