### PR TITLE
Updated `EntryDatetime` in EF Model

### DIFF
--- a/ClimsoftVer4/ClimsoftVer4/App.config
+++ b/ClimsoftVer4/ClimsoftVer4/App.config
@@ -37,4 +37,7 @@
       <add name="MySQL Data Provider" invariant="MySql.Data.MySqlClient" description=".Net Framework Data Provider for MySQL" type="MySql.Data.MySqlClient.MySqlClientFactory, MySql.Data, Version=6.9.10.0, Culture=neutral, PublicKeyToken=c5687fc88969c44d" />
     </DbProviderFactories>
   </system.data>
-<connectionStrings><add name="mariadb_climsoft_test_db_v4Entities" connectionString="metadata=res://*/Model1.csdl|res://*/Model1.ssdl|res://*/Model1.msl;provider=MySql.Data.MySqlClient;provider connection string=&quot;server=127.0.0.1;user id=root;persistsecurityinfo=True;database=mariadb_climsoft_test_db_v4&quot;" providerName="System.Data.EntityClient" /></connectionStrings></configuration>
+  <connectionStrings>
+    <add name="mariadb_climsoft_test_db_v4Entities" connectionString="metadata=res://*/Model1.csdl|res://*/Model1.ssdl|res://*/Model1.msl;provider=MySql.Data.MySqlClient;provider connection string=&quot;server=127.0.0.1;user id=root;persistsecurityinfo=True;database=mariadb_climsoft_test_db_v4&quot;" providerName="System.Data.EntityClient" />
+  </connectionStrings>
+</configuration>

--- a/ClimsoftVer4/ClimsoftVer4/Model1.edmx
+++ b/ClimsoftVer4/ClimsoftVer4/Model1.edmx
@@ -611,7 +611,7 @@ warning 6002: The table/view 'def.mariadb_climsoft_test_db_v4.featuregeographica
           <Property Name="period31" Type="varchar" MaxLength="45" />
           <Property Name="total" Type="varchar" MaxLength="45" />
           <Property Name="signature" Type="varchar" MaxLength="45" />
-          <Property Name="EntryDatetime" Type="varchar" MaxLength="45" />
+          <Property Name="EntryDatetime" Type="datetime" Precision="0" />
           <Property Name="temperatureUnits" Type="varchar" MaxLength="45" />
           <Property Name="precipUnits" Type="varchar" MaxLength="45" />
           <Property Name="cloudHeightUnits" Type="varchar" MaxLength="45" />
@@ -680,7 +680,7 @@ warning 6002: The table/view 'def.mariadb_climsoft_test_db_v4.featuregeographica
           <Property Name="flag23" Type="varchar" MaxLength="50" />
           <Property Name="total" Type="varchar" MaxLength="50" />
           <Property Name="signature" Type="varchar" MaxLength="50" />
-          <Property Name="EntryDatetime" Type="varchar" MaxLength="50" />
+          <Property Name="EntryDatetime" Type="datetime" Precision="0" />
         </EntityType>
         <EntityType Name="form_hourly_time_selection">
           <Key>
@@ -2625,7 +2625,7 @@ FROM `seq_month_day_element_leap_yr` AS `seq_month_day_element_leap_yr`</Definin
           <Property Name="period31" Type="String" MaxLength="45" FixedLength="false" Unicode="false" />
           <Property Name="total" Type="String" MaxLength="45" FixedLength="false" Unicode="false" />
           <Property Name="signature" Type="String" MaxLength="45" FixedLength="false" Unicode="false" />
-          <Property Name="EntryDatetime" Type="String" MaxLength="45" FixedLength="false" Unicode="false" />
+          <Property Name="EntryDatetime" Type="DateTime" />
           <Property Name="temperatureUnits" Type="String" MaxLength="45" FixedLength="false" Unicode="false" />
           <Property Name="precipUnits" Type="String" MaxLength="45" FixedLength="false" Unicode="false" />
           <Property Name="cloudHeightUnits" Type="String" MaxLength="45" FixedLength="false" Unicode="false" />
@@ -2694,7 +2694,7 @@ FROM `seq_month_day_element_leap_yr` AS `seq_month_day_element_leap_yr`</Definin
           <Property Name="flag23" Type="String" MaxLength="50" FixedLength="false" Unicode="false" />
           <Property Name="total" Type="String" MaxLength="50" FixedLength="false" Unicode="false" />
           <Property Name="signature" Type="String" MaxLength="50" FixedLength="false" Unicode="false" />
-          <Property Name="EntryDatetime" Type="String" MaxLength="50" FixedLength="false" Unicode="false" />
+          <Property Name="EntryDatetime" Type="DateTime" />
         </EntityType>
         <EntityType Name="form_hourly_time_selection">
           <Key>

--- a/ClimsoftVer4/ClimsoftVer4/Model1.edmx.diagram
+++ b/ClimsoftVer4/ClimsoftVer4/Model1.edmx.diagram
@@ -4,7 +4,7 @@
   <edmx:Designer xmlns="http://schemas.microsoft.com/ado/2009/11/edmx">
     <!-- Diagram content (shape and connector positions) -->
     <edmx:Diagrams>
-      <Diagram DiagramId="d0e1d8d670e240ab9385cd23d8d7c14a" Name="Diagram1">
+      <Diagram DiagramId="3adfa675a87e4c3da95dd0afed70ef11" Name="Diagram1">
         <EntityTypeShape EntityType="mariadb_climsoft_test_db_v4Model.acquisitiontype" Width="1.5" PointX="0.75" PointY="0.75" IsExpanded="true" />
         <EntityTypeShape EntityType="mariadb_climsoft_test_db_v4Model.aws_basestation" Width="1.5" PointX="2.75" PointY="0.75" IsExpanded="true" />
         <EntityTypeShape EntityType="mariadb_climsoft_test_db_v4Model.aws_elements" Width="1.5" PointX="0.75" PointY="3.75" IsExpanded="true" />

--- a/ClimsoftVer4/ClimsoftVer4/form_daily2.vb
+++ b/ClimsoftVer4/ClimsoftVer4/form_daily2.vb
@@ -111,7 +111,7 @@ Partial Public Class form_daily2
     Public Property period31 As String
     Public Property total As String
     Public Property signature As String
-    Public Property EntryDatetime As String
+    Public Property EntryDatetime As Nullable(Of Date)
     Public Property temperatureUnits As String
     Public Property precipUnits As String
     Public Property cloudHeightUnits As String

--- a/ClimsoftVer4/ClimsoftVer4/form_hourly.vb
+++ b/ClimsoftVer4/ClimsoftVer4/form_hourly.vb
@@ -66,6 +66,6 @@ Partial Public Class form_hourly
     Public Property flag23 As String
     Public Property total As String
     Public Property signature As String
-    Public Property EntryDatetime As String
+    Public Property EntryDatetime As Nullable(Of Date)
 
 End Class


### PR DESCRIPTION
Updated `EntryDatetime` in `form_daily2` and `form_hourly` replacing `VARCHAR` with `DATETIME`. Fixes #388