### PR TITLE
modified navigation user control to not load all records into forms

### DIFF
--- a/ClimsoftVer4/ClimsoftVer4/clsDataCall.vb
+++ b/ClimsoftVer4/ClimsoftVer4/clsDataCall.vb
@@ -205,7 +205,7 @@ Public Class DataCall
             clsCurrentFilter = clsFilter
         End If
 
-            Try
+        Try
             If strTable <> "" Then
                 Dim x = CallByName(clsDataConnection.db, strTable, CallType.Get)
                 Dim y = TryCast(x, IQueryable(Of Object))
@@ -248,5 +248,11 @@ Public Class DataCall
     'TODO This should return the Linq expression that goes in the Select method
     Public Function GetSelectLinqExpression() As String
         Return ""
+    End Function
+
+    Public Function GetTableCount() As Integer
+        Dim x = CallByName(clsDataConnection.db, GetTableName(), CallType.Get)
+        Dim y = TryCast(x, IQueryable(Of Object))
+        Return y.Count()
     End Function
 End Class

--- a/ClimsoftVer4/ClimsoftVer4/clsDataCall.vb
+++ b/ClimsoftVer4/ClimsoftVer4/clsDataCall.vb
@@ -250,9 +250,34 @@ Public Class DataCall
         Return ""
     End Function
 
-    Public Function GetTableCount() As Integer
-        Dim x = CallByName(clsDataConnection.db, GetTableName(), CallType.Get)
-        Dim y = TryCast(x, IQueryable(Of Object))
-        Return y.Count()
+    Public Function TableCount(Optional clsAdditionalFilter As TableFilter = Nothing) As Integer
+        Dim clsCurrentFilter As TableFilter
+
+        If Not IsNothing(clsAdditionalFilter) Then
+            If IsNothing(clsFilter) Then
+                clsCurrentFilter = clsAdditionalFilter
+            Else
+                clsCurrentFilter = New TableFilter(clsFilter, clsAdditionalFilter)
+            End If
+        Else
+            clsCurrentFilter = clsFilter
+        End If
+
+        Try
+            If strTable <> "" Then
+                Dim x = CallByName(clsDataConnection.db, strTable, CallType.Get)
+                Dim y = TryCast(x, IQueryable(Of Object))
+
+                If clsCurrentFilter IsNot Nothing Then
+                    y = y.Where(clsCurrentFilter.GetLinqExpression())
+                End If
+                Return y.Count()
+            Else
+                MessageBox.Show("Developer error: Table name must be set before data can be retrieved. No data will be returned.", caption:="Developer error")
+                Return 0
+            End If
+        Catch ex As Exception
+            Return 0
+        End Try
     End Function
 End Class

--- a/ClimsoftVer4/ClimsoftVer4/clsDataCall.vb
+++ b/ClimsoftVer4/ClimsoftVer4/clsDataCall.vb
@@ -51,6 +51,10 @@ Public Class DataCall
         strTable = strNewTable
     End Sub
 
+    Public Function GetTableName() As String
+        Return strTable
+    End Function
+
     Public Sub SetFields(dctNewFields As Dictionary(Of String, List(Of String)))
         dctFields = dctNewFields
     End Sub

--- a/ClimsoftVer4/ClimsoftVer4/ucrNavigation.vb
+++ b/ClimsoftVer4/ClimsoftVer4/ucrNavigation.vb
@@ -13,7 +13,7 @@
         ' This is the cause of slow loading - getting all records into dtbRecords is slow.
         'MyBase.PopulateControl()
 
-        iMaxRows = clsDataDefinition.GetTableCount()
+        iMaxRows = clsDataDefinition.TableCount()
         iCurrRow = 0
         'If strSortCol <> "" AndAlso dtbRecords.Columns.Contains(strSortCol) Then
         '    dtbRecords.DefaultView.Sort = strSortCol & " ASC"
@@ -338,7 +338,11 @@
     Private Function GetRow(iRow As Integer) As Object
         'Skip() and FirstOrDefault() seems like the way to get the nth row from the table
         'You can only use Skip() if you use an Order function first.
-        'We might want to sort the records for the sequencer anyway?
-        Return clsDataConnection.db.form_daily2.OrderByDescending(Function(u) u.stationId).Skip(iRow).FirstOrDefault()
+
+        Dim x = CallByName(clsDataConnection.db, clsDataDefinition.GetTableName(), CallType.Get)
+        Dim y = TryCast(x, IQueryable(Of Object))
+
+        ' OrderBy function returns 1 to give a default ordering
+        Return y.OrderBy(Function(u) 1).Skip(iRow).FirstOrDefault()
     End Function
 End Class

--- a/ClimsoftVer4/ClimsoftVer4/ucrNavigation.vb
+++ b/ClimsoftVer4/ClimsoftVer4/ucrNavigation.vb
@@ -13,14 +13,7 @@
         ' This is the cause of slow loading - getting all records into dtbRecords is slow.
         'MyBase.PopulateControl()
 
-        ' Instead of getting the full table just get the number of rows.
-        ' This should work but doesn't for some reason.
-        'iMaxRows = CallByName(CallByName(clsDataConnection.db, clsDataDefinition.GetTableName(), CallType.Get), "Count", CallType.Method)
-        ' Tried this as an alternative too but gives same error
-        'Dim objTemp As Object = CallByName(clsDataConnection.db, clsDataDefinition.GetTableName(), CallType.Get)
-        'iMaxRows = CallByName(objTemp, "Count", CallType.Method)
-        ' Doing this to test with form_daily2 until work out how to do in general.
-        iMaxRows = clsDataConnection.db.form_daily2.Count()
+        iMaxRows = clsDataDefinition.GetTableCount()
         iCurrRow = 0
         'If strSortCol <> "" AndAlso dtbRecords.Columns.Contains(strSortCol) Then
         '    dtbRecords.DefaultView.Sort = strSortCol & " ASC"
@@ -344,7 +337,7 @@
 
     Private Function GetRow(iRow As Integer) As Object
         'Skip() and FirstOrDefault() seems like the way to get the nth row from the table
-        'For some reason you can only use Skip() if you use an Order function first.
+        'You can only use Skip() if you use an Order function first.
         'We might want to sort the records for the sequencer anyway?
         Return clsDataConnection.db.form_daily2.OrderByDescending(Function(u) u.stationId).Skip(iRow).FirstOrDefault()
     End Function

--- a/ClimsoftVer4/ClimsoftVer4/ucrNavigation.vb
+++ b/ClimsoftVer4/ClimsoftVer4/ucrNavigation.vb
@@ -342,10 +342,9 @@
     Private Function GetRow(iRow As Integer) As Object
         'Skip() and FirstOrDefault() seems like the way to get the nth row from the table
         'You can only use Skip() if you use an Order function first.
-
         Dim x = CallByName(clsDataConnection.db, clsDataDefinition.GetTableName(), CallType.Get)
+        x = x.AsNoTracking()
         Dim y = TryCast(x, IQueryable(Of Object))
-
         ' OrderBy function returns 1 to give a default ordering
         Return y.OrderBy(Function(u) 1).Skip(iRow).FirstOrDefault()
     End Function

--- a/ClimsoftVer4/ClimsoftVer4/ucrNavigation.vb
+++ b/ClimsoftVer4/ClimsoftVer4/ucrNavigation.vb
@@ -338,11 +338,7 @@
         If iMaxRows = 0 Then
             Return ""
         Else
-            Dim watch As Stopwatch = Stopwatch.StartNew()
-            Dim strVal As String = CallByName(GetRow(iRow), strField, CallType.Get)
-            watch.Stop()
-            Console.WriteLine("Time: " & watch.Elapsed.TotalMilliseconds)
-            Return strVal
+            Return CallByName(GetRow(iRow), strField, CallType.Get)
         End If
     End Function
 

--- a/ClimsoftVer4/ClimsoftVer4/ucrNavigation.vb
+++ b/ClimsoftVer4/ClimsoftVer4/ucrNavigation.vb
@@ -22,7 +22,7 @@
         UpdateKeyControls()
     End Sub
     ''' <summary>
-    ''' Gets the value of the specified column(strFieldName) at the current row 
+    ''' Gets the value of the specified column (strFieldName) at the current row 
     ''' Returns empty string or nothing if no rows found or strFieldName is not specified
     ''' </summary>
     ''' <param name="strFieldName"></param>
@@ -36,7 +36,11 @@
         'Else
         '    Return ""
         'End If
-        Return GetValueFromRow(iCurrRow, strFieldName)
+        If iMaxRows > 0 Then
+            Return GetValueFromRow(iCurrRow, strFieldName)
+        Else
+            Return ""
+        End If
     End Function
     ''' <summary>
     ''' Displays the record number for the navigation control

--- a/ClimsoftVer4/ClimsoftVer4/ucrNavigation.vb
+++ b/ClimsoftVer4/ClimsoftVer4/ucrNavigation.vb
@@ -10,12 +10,21 @@
     Private dctKeyControls As Dictionary(Of String, ucrBaseDataLink)
 
     Public Overrides Sub PopulateControl()
-        MyBase.PopulateControl()
+        ' This is the cause of slow loading - getting all records into dtbRecords is slow.
+        'MyBase.PopulateControl()
+
+        ' Instead of getting the full table just get the number of rows.
+        ' This should work but doesn't for some reason.
+        'iMaxRows = CallByName(CallByName(clsDataConnection.db, clsDataDefinition.GetTableName(), CallType.Get), "Count", CallType.Method)
+        ' Tried this as an alternative too but gives same error
+        'Dim objTemp As Object = CallByName(clsDataConnection.db, clsDataDefinition.GetTableName(), CallType.Get)
+        'iMaxRows = CallByName(objTemp, "Count", CallType.Method)
+        ' Doing this to test with form_daily2 until work out how to do in general.
+        iMaxRows = clsDataConnection.db.form_daily2.Count()
         iCurrRow = 0
-        iMaxRows = dtbRecords.Rows.Count
-        If strSortCol <> "" AndAlso dtbRecords.Columns.Contains(strSortCol) Then
-            dtbRecords.DefaultView.Sort = strSortCol & " ASC"
-        End If
+        'If strSortCol <> "" AndAlso dtbRecords.Columns.Contains(strSortCol) Then
+        '    dtbRecords.DefaultView.Sort = strSortCol & " ASC"
+        'End If
         displayRecordNumber()
         UpdateKeyControls()
     End Sub
@@ -29,12 +38,12 @@
         If strFieldName = "" Then
             Return Nothing
         End If
-
-        If dtbRecords.Rows.Count > 0 Then
-            Return dtbRecords.Rows(iCurrRow).Item(strFieldName)
-        Else
-            Return ""
-        End If
+        'If dtbRecords.Rows.Count > 0 Then
+        '    Return dtbRecords.Rows(iCurrRow).Item(strFieldName)
+        'Else
+        '    Return ""
+        'End If
+        Return GetValueFromRow(iCurrRow, strFieldName)
     End Function
     ''' <summary>
     ''' Displays the record number for the navigation control
@@ -155,7 +164,9 @@
                 For Each kvp As KeyValuePair(Of String, ucrBaseDataLink) In dctKeyControls
                     'Suppress events being raised while changing value of each key control
                     kvp.Value.bSuppressChangedEvents = True
-                    kvp.Value.SetValue(dtbRecords.Rows(iCurrRow).Item(kvp.Key))
+                    ' Use new GetValueFromRow method to get value from specific row since dtbRecords now nothing
+                    kvp.Value.SetValue(GetValueFromRow(iCurrRow, kvp.Key))
+                    'kvp.Value.SetValue(dtbRecords.Rows(iCurrRow).Item(kvp.Key))
                     kvp.Value.bSuppressChangedEvents = False
                 Next
             End If
@@ -173,7 +184,8 @@
     Public Sub UpdateNavigationByKeyControls()
         Dim dctFieldvalue As New Dictionary(Of String, String)
         Dim bRowExists As Boolean
-        Dim row As DataRow
+        'Dim row As DataRow
+        Dim row As Object
 
         If dctKeyControls IsNot Nothing AndAlso dctKeyControls.Count > 0 AndAlso iMaxRows > 0 Then
             iCurrRow = -1
@@ -181,12 +193,14 @@
                 dctFieldvalue.Add(kvp.Key, kvp.Value.GetValue)
             Next
 
-            For i As Integer = 0 To dtbRecords.Rows.Count - 1
-                row = dtbRecords.Rows(i)
+            For i As Integer = 0 To iMaxRows - 1
+                ' Here use GetRow() since we want multiple fields.
+                row = GetRow(i)
                 bRowExists = True
                 For Each kvp As KeyValuePair(Of String, String) In dctFieldvalue
 
-                    If Not (row(kvp.Key) = kvp.Value) Then
+                    'If Not (row(kvp.Key) = kvp.Value) Then
+                    If Not (CallByName(row, kvp.Key, CallType.Get) = kvp.Value) Then
                         bRowExists = False
                         Exit For
                     End If
@@ -318,4 +332,24 @@
 
     End Sub
 
+    ' Use these two methods when you need to get a values from a specific row of the table
+    ' These should be used in any place where dtbRecords is currently used since we are now not populating dtbRecords
+    Private Function GetValueFromRow(iRow As Integer, strField As String) As String
+        If iMaxRows = 0 Then
+            Return ""
+        Else
+            Dim watch As Stopwatch = Stopwatch.StartNew()
+            Dim strVal As String = CallByName(GetRow(iRow), strField, CallType.Get)
+            watch.Stop()
+            Console.WriteLine("Time: " & watch.Elapsed.TotalMilliseconds)
+            Return strVal
+        End If
+    End Function
+
+    Private Function GetRow(iRow As Integer) As Object
+        'Skip() and FirstOrDefault() seems like the way to get the nth row from the table
+        'For some reason you can only use Skip() if you use an Order function first.
+        'We might want to sort the records for the sequencer anyway?
+        Return clsDataConnection.db.form_daily2.OrderByDescending(Function(u) u.stationId).Skip(iRow).FirstOrDefault()
+    End Function
 End Class


### PR DESCRIPTION
This addresses #392

Main changes:
- `ucrNavigation` doesn't populate the data table on load (`PopulateControl `method), only gets the number of records, so time taken to load form is reduced
- Two new methods added: `GetRow` and `GetValueFromRow` to get single row from database when needed since data table of all rows no longer stored

This is not yet complete or ready for merging. @volloholic @Patowhiz please take over from here, further details in code comments.