### PR TITLE
Improvements to managing database connections at login

### DIFF
--- a/ClimsoftVer4/ClimsoftVer4/App.config
+++ b/ClimsoftVer4/ClimsoftVer4/App.config
@@ -6,18 +6,22 @@
     </sectionGroup>
     <!-- For more information on Entity Framework configuration, visit http://go.microsoft.com/fwlink/?LinkID=237468 -->
     <section name="entityFramework" type="System.Data.Entity.Internal.ConfigFile.EntityFrameworkSection, EntityFramework, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" requirePermission="false" />
+  
+      <sectionGroup name="userSettings" type="System.Configuration.UserSettingsGroup, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" >
+          <section name="ClimsoftVer4.My.MySettings" type="System.Configuration.ClientSettingsSection, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" allowExeDefinition="MachineToLocalUser" requirePermission="false" />
+      </sectionGroup>
   </configSections>
   <startup>
     <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5.1" />
   </startup>
   <applicationSettings>
     <ClimsoftVer4.My.MySettings>
-      <setting name="defaultDatabase" serializeAs="String">
-        <value>server=localhost;database=mariadb_climsoft_db_v4;port=3308;</value>
-      </setting>
-      <setting name="defaultRLocation" serializeAs="String">
-        <value>C:\Program Files\R\R-3.2.1</value>
-      </setting>
+        <setting name="defaultDatabase" serializeAs="String">
+            <value>server=localhost;database=mariadb_climsoft_db_v4;port=3308;</value>
+        </setting>
+        <setting name="defaultRLocation" serializeAs="String">
+            <value>C:\Program Files\R\R-3.2.1</value>
+        </setting>
     </ClimsoftVer4.My.MySettings>
   </applicationSettings>
   <entityFramework>
@@ -40,4 +44,14 @@
   <connectionStrings>
     <add name="mariadb_climsoft_test_db_v4Entities" connectionString="metadata=res://*/Model1.csdl|res://*/Model1.ssdl|res://*/Model1.msl;provider=MySql.Data.MySqlClient;provider connection string=&quot;server=127.0.0.1;user id=root;persistsecurityinfo=True;database=mariadb_climsoft_test_db_v4&quot;" providerName="System.Data.EntityClient" />
   </connectionStrings>
+<userSettings>
+        <ClimsoftVer4.My.MySettings>
+            <setting name="rememberUsername" serializeAs="String">
+                <value>False</value>
+            </setting>
+            <setting name="rememberedUsername" serializeAs="String">
+                <value />
+            </setting>
+        </ClimsoftVer4.My.MySettings>
+    </userSettings>
 </configuration>

--- a/ClimsoftVer4/ClimsoftVer4/ClimsoftVer4.vbproj
+++ b/ClimsoftVer4/ClimsoftVer4/ClimsoftVer4.vbproj
@@ -23,6 +23,7 @@
     <OutputPath>bin\Debug\</OutputPath>
     <DocumentationFile>ClimsoftVer4.xml</DocumentationFile>
     <NoWarn>42016,41999,42017,42018,42019,42032,42036,42020,42021,42022</NoWarn>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>
@@ -237,6 +238,12 @@
       <DependentUpon>frmCharts.vb</DependentUpon>
     </Compile>
     <Compile Include="frmCharts.vb">
+      <SubType>Form</SubType>
+    </Compile>
+    <Compile Include="frmDatabaseConnections.Designer.vb">
+      <DependentUpon>frmDatabaseConnections.vb</DependentUpon>
+    </Compile>
+    <Compile Include="frmDatabaseConnections.vb">
       <SubType>Form</SubType>
     </Compile>
     <Compile Include="frmElementSequencerMonthly.Designer.vb">
@@ -1065,6 +1072,9 @@
     <EmbeddedResource Include="frmCharts.resx">
       <DependentUpon>frmCharts.vb</DependentUpon>
     </EmbeddedResource>
+    <EmbeddedResource Include="frmDatabaseConnections.resx">
+      <DependentUpon>frmDatabaseConnections.vb</DependentUpon>
+    </EmbeddedResource>
     <EmbeddedResource Include="frmElementSequencerMonthly.resx">
       <DependentUpon>frmElementSequencerMonthly.vb</DependentUpon>
     </EmbeddedResource>
@@ -1629,9 +1639,6 @@
     <XliffResource Include="MultilingualResources\ClimsoftVer4.fr.xlf" />
   </ItemGroup>
   <ItemGroup>
-    <Content Include="config.inf">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </Content>
     <Content Include="Model1.Context.tt">
       <Generator>TextTemplatingFileGenerator</Generator>
       <DependentUpon>Model1.edmx</DependentUpon>

--- a/ClimsoftVer4/ClimsoftVer4/My Project/Settings.Designer.vb
+++ b/ClimsoftVer4/ClimsoftVer4/My Project/Settings.Designer.vb
@@ -15,7 +15,7 @@ Option Explicit On
 Namespace My
     
     <Global.System.Runtime.CompilerServices.CompilerGeneratedAttribute(),  _
-     Global.System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "15.8.0.0"),  _
+     Global.System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "15.5.0.0"),  _
      Global.System.ComponentModel.EditorBrowsableAttribute(Global.System.ComponentModel.EditorBrowsableState.Advanced)>  _
     Partial Friend NotInheritable Class MySettings
         Inherits Global.System.Configuration.ApplicationSettingsBase
@@ -70,6 +70,30 @@ Namespace My
             Get
                 Return CType(Me("defaultRLocation"),String)
             End Get
+        End Property
+        
+        <Global.System.Configuration.UserScopedSettingAttribute(),  _
+         Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),  _
+         Global.System.Configuration.DefaultSettingValueAttribute("False")>  _
+        Public Property rememberUsername() As Boolean
+            Get
+                Return CType(Me("rememberUsername"),Boolean)
+            End Get
+            Set
+                Me("rememberUsername") = value
+            End Set
+        End Property
+        
+        <Global.System.Configuration.UserScopedSettingAttribute(),  _
+         Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),  _
+         Global.System.Configuration.DefaultSettingValueAttribute("")>  _
+        Public Property rememberedUsername() As String
+            Get
+                Return CType(Me("rememberedUsername"),String)
+            End Get
+            Set
+                Me("rememberedUsername") = value
+            End Set
         End Property
     End Class
 End Namespace

--- a/ClimsoftVer4/ClimsoftVer4/My Project/Settings.settings
+++ b/ClimsoftVer4/ClimsoftVer4/My Project/Settings.settings
@@ -8,5 +8,11 @@
     <Setting Name="defaultRLocation" Type="System.String" Scope="Application">
       <Value Profile="(Default)">C:\Program Files\R\R-3.2.1</Value>
     </Setting>
+    <Setting Name="rememberUsername" Type="System.Boolean" Scope="User">
+      <Value Profile="(Default)">False</Value>
+    </Setting>
+    <Setting Name="rememberedUsername" Type="System.String" Scope="User">
+      <Value Profile="(Default)" />
+    </Setting>
   </Settings>
 </SettingsFile>

--- a/ClimsoftVer4/ClimsoftVer4/config.inf
+++ b/ClimsoftVer4/ClimsoftVer4/config.inf
@@ -1,2 +1,0 @@
-server=127.0.0.1;database=mariadb_climsoft_db_v4;port=3308;
-

--- a/ClimsoftVer4/ClimsoftVer4/frmDatabaseConnections.Designer.vb
+++ b/ClimsoftVer4/ClimsoftVer4/frmDatabaseConnections.Designer.vb
@@ -1,0 +1,307 @@
+﻿<Global.Microsoft.VisualBasic.CompilerServices.DesignerGenerated()> _
+Partial Class frmDatabaseConnections
+    Inherits System.Windows.Forms.Form
+
+    'Form overrides dispose to clean up the component list.
+    <System.Diagnostics.DebuggerNonUserCode()> _
+    Protected Overrides Sub Dispose(ByVal disposing As Boolean)
+        Try
+            If disposing AndAlso components IsNot Nothing Then
+                components.Dispose()
+            End If
+        Finally
+            MyBase.Dispose(disposing)
+        End Try
+    End Sub
+
+    'Required by the Windows Form Designer
+    Private components As System.ComponentModel.IContainer
+
+    'NOTE: The following procedure is required by the Windows Form Designer
+    'It can be modified using the Windows Form Designer.  
+    'Do not modify it using the code editor.
+    <System.Diagnostics.DebuggerStepThrough()> _
+    Private Sub InitializeComponent()
+        Me.DataGridView1 = New System.Windows.Forms.DataGridView()
+        Me.connection = New System.Windows.Forms.DataGridViewTextBoxColumn()
+        Me.server = New System.Windows.Forms.DataGridViewTextBoxColumn()
+        Me.database = New System.Windows.Forms.DataGridViewTextBoxColumn()
+        Me.port = New System.Windows.Forms.DataGridViewTextBoxColumn()
+        Me.cmdCancel = New System.Windows.Forms.Button()
+        Me.grpCurrentSelection = New System.Windows.Forms.GroupBox()
+        Me.cmdMakeDefault = New System.Windows.Forms.Button()
+        Me.cmdTest = New System.Windows.Forms.Button()
+        Me.cmdRemove = New System.Windows.Forms.Button()
+        Me.grpDefaults = New System.Windows.Forms.GroupBox()
+        Me.Label10 = New System.Windows.Forms.Label()
+        Me.Label9 = New System.Windows.Forms.Label()
+        Me.Label8 = New System.Windows.Forms.Label()
+        Me.Label7 = New System.Windows.Forms.Label()
+        Me.Label4 = New System.Windows.Forms.Label()
+        Me.Label5 = New System.Windows.Forms.Label()
+        Me.Label6 = New System.Windows.Forms.Label()
+        Me.Label3 = New System.Windows.Forms.Label()
+        Me.Label2 = New System.Windows.Forms.Label()
+        Me.Label1 = New System.Windows.Forms.Label()
+        Me.cmdOK = New System.Windows.Forms.Button()
+        CType(Me.DataGridView1, System.ComponentModel.ISupportInitialize).BeginInit()
+        Me.grpCurrentSelection.SuspendLayout()
+        Me.grpDefaults.SuspendLayout()
+        Me.SuspendLayout()
+        '
+        'DataGridView1
+        '
+        Me.DataGridView1.ColumnHeadersHeightSizeMode = System.Windows.Forms.DataGridViewColumnHeadersHeightSizeMode.AutoSize
+        Me.DataGridView1.Columns.AddRange(New System.Windows.Forms.DataGridViewColumn() {Me.connection, Me.server, Me.database, Me.port})
+        Me.DataGridView1.Location = New System.Drawing.Point(12, 12)
+        Me.DataGridView1.MultiSelect = False
+        Me.DataGridView1.Name = "DataGridView1"
+        Me.DataGridView1.ScrollBars = System.Windows.Forms.ScrollBars.Vertical
+        Me.DataGridView1.Size = New System.Drawing.Size(627, 208)
+        Me.DataGridView1.TabIndex = 0
+        '
+        'connection
+        '
+        Me.connection.HeaderText = "Connection name"
+        Me.connection.Name = "connection"
+        Me.connection.Width = 150
+        '
+        'server
+        '
+        Me.server.HeaderText = "Server address"
+        Me.server.Name = "server"
+        Me.server.Width = 150
+        '
+        'database
+        '
+        Me.database.HeaderText = "Database name"
+        Me.database.Name = "database"
+        Me.database.Width = 200
+        '
+        'port
+        '
+        Me.port.HeaderText = "Port number"
+        Me.port.Name = "port"
+        Me.port.Width = 60
+        '
+        'cmdCancel
+        '
+        Me.cmdCancel.Location = New System.Drawing.Point(564, 360)
+        Me.cmdCancel.Name = "cmdCancel"
+        Me.cmdCancel.Size = New System.Drawing.Size(75, 23)
+        Me.cmdCancel.TabIndex = 4
+        Me.cmdCancel.Text = "Cancel"
+        Me.cmdCancel.UseVisualStyleBackColor = True
+        '
+        'grpCurrentSelection
+        '
+        Me.grpCurrentSelection.Controls.Add(Me.cmdMakeDefault)
+        Me.grpCurrentSelection.Controls.Add(Me.cmdTest)
+        Me.grpCurrentSelection.Controls.Add(Me.cmdRemove)
+        Me.grpCurrentSelection.Enabled = False
+        Me.grpCurrentSelection.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.25!, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
+        Me.grpCurrentSelection.Location = New System.Drawing.Point(483, 239)
+        Me.grpCurrentSelection.Name = "grpCurrentSelection"
+        Me.grpCurrentSelection.Size = New System.Drawing.Size(156, 115)
+        Me.grpCurrentSelection.TabIndex = 6
+        Me.grpCurrentSelection.TabStop = False
+        Me.grpCurrentSelection.Text = "Current selection"
+        '
+        'cmdMakeDefault
+        '
+        Me.cmdMakeDefault.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.25!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
+        Me.cmdMakeDefault.Location = New System.Drawing.Point(21, 23)
+        Me.cmdMakeDefault.Name = "cmdMakeDefault"
+        Me.cmdMakeDefault.Size = New System.Drawing.Size(117, 23)
+        Me.cmdMakeDefault.TabIndex = 5
+        Me.cmdMakeDefault.Text = "Make default"
+        Me.cmdMakeDefault.UseVisualStyleBackColor = True
+        '
+        'cmdTest
+        '
+        Me.cmdTest.Enabled = False
+        Me.cmdTest.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.25!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
+        Me.cmdTest.Location = New System.Drawing.Point(21, 52)
+        Me.cmdTest.Name = "cmdTest"
+        Me.cmdTest.Size = New System.Drawing.Size(117, 23)
+        Me.cmdTest.TabIndex = 4
+        Me.cmdTest.Text = "Test connection"
+        Me.cmdTest.UseVisualStyleBackColor = True
+        '
+        'cmdRemove
+        '
+        Me.cmdRemove.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.25!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
+        Me.cmdRemove.Location = New System.Drawing.Point(21, 81)
+        Me.cmdRemove.Name = "cmdRemove"
+        Me.cmdRemove.Size = New System.Drawing.Size(117, 23)
+        Me.cmdRemove.TabIndex = 3
+        Me.cmdRemove.Text = "Remove connection"
+        Me.cmdRemove.UseVisualStyleBackColor = True
+        '
+        'grpDefaults
+        '
+        Me.grpDefaults.Controls.Add(Me.Label10)
+        Me.grpDefaults.Controls.Add(Me.Label9)
+        Me.grpDefaults.Controls.Add(Me.Label8)
+        Me.grpDefaults.Controls.Add(Me.Label7)
+        Me.grpDefaults.Controls.Add(Me.Label4)
+        Me.grpDefaults.Controls.Add(Me.Label5)
+        Me.grpDefaults.Controls.Add(Me.Label6)
+        Me.grpDefaults.Controls.Add(Me.Label3)
+        Me.grpDefaults.Controls.Add(Me.Label2)
+        Me.grpDefaults.Controls.Add(Me.Label1)
+        Me.grpDefaults.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.25!, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
+        Me.grpDefaults.Location = New System.Drawing.Point(12, 239)
+        Me.grpDefaults.Name = "grpDefaults"
+        Me.grpDefaults.Size = New System.Drawing.Size(465, 144)
+        Me.grpDefaults.TabIndex = 7
+        Me.grpDefaults.TabStop = False
+        Me.grpDefaults.Text = "Example connections"
+        '
+        'Label10
+        '
+        Me.Label10.AutoSize = True
+        Me.Label10.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.25!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
+        Me.Label10.Location = New System.Drawing.Point(173, 120)
+        Me.Label10.Name = "Label10"
+        Me.Label10.Size = New System.Drawing.Size(83, 13)
+        Me.Label10.TabIndex = 9
+        Me.Label10.Text = "MariaDB default"
+        '
+        'Label9
+        '
+        Me.Label9.AutoSize = True
+        Me.Label9.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.25!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
+        Me.Label9.Location = New System.Drawing.Point(173, 104)
+        Me.Label9.Name = "Label9"
+        Me.Label9.Size = New System.Drawing.Size(77, 13)
+        Me.Label9.TabIndex = 8
+        Me.Label9.Text = "MySQL default"
+        '
+        'Label8
+        '
+        Me.Label8.AutoSize = True
+        Me.Label8.Location = New System.Drawing.Point(121, 120)
+        Me.Label8.Name = "Label8"
+        Me.Label8.Size = New System.Drawing.Size(35, 13)
+        Me.Label8.TabIndex = 7
+        Me.Label8.Text = "3308"
+        '
+        'Label7
+        '
+        Me.Label7.AutoSize = True
+        Me.Label7.Location = New System.Drawing.Point(121, 74)
+        Me.Label7.Name = "Label7"
+        Me.Label7.Size = New System.Drawing.Size(171, 13)
+        Me.Label7.TabIndex = 6
+        Me.Label7.Text = "mariadb_climsoft_test_db_v4"
+        '
+        'Label4
+        '
+        Me.Label4.AutoSize = True
+        Me.Label4.Location = New System.Drawing.Point(121, 105)
+        Me.Label4.Name = "Label4"
+        Me.Label4.Size = New System.Drawing.Size(35, 13)
+        Me.Label4.TabIndex = 5
+        Me.Label4.Text = "3306"
+        '
+        'Label5
+        '
+        Me.Label5.AutoSize = True
+        Me.Label5.Location = New System.Drawing.Point(121, 57)
+        Me.Label5.Name = "Label5"
+        Me.Label5.Size = New System.Drawing.Size(143, 13)
+        Me.Label5.TabIndex = 4
+        Me.Label5.Text = "mariadb_climsoft_db_v4"
+        '
+        'Label6
+        '
+        Me.Label6.AutoSize = True
+        Me.Label6.Location = New System.Drawing.Point(121, 29)
+        Me.Label6.Name = "Label6"
+        Me.Label6.Size = New System.Drawing.Size(61, 13)
+        Me.Label6.TabIndex = 3
+        Me.Label6.Text = "127.0.0.1"
+        '
+        'Label3
+        '
+        Me.Label3.AutoSize = True
+        Me.Label3.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.25!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
+        Me.Label3.Location = New System.Drawing.Point(15, 104)
+        Me.Label3.Name = "Label3"
+        Me.Label3.Size = New System.Drawing.Size(64, 13)
+        Me.Label3.TabIndex = 2
+        Me.Label3.Text = "Port number"
+        '
+        'Label2
+        '
+        Me.Label2.AutoSize = True
+        Me.Label2.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.25!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
+        Me.Label2.Location = New System.Drawing.Point(15, 56)
+        Me.Label2.Name = "Label2"
+        Me.Label2.Size = New System.Drawing.Size(82, 13)
+        Me.Label2.TabIndex = 1
+        Me.Label2.Text = "Database name"
+        '
+        'Label1
+        '
+        Me.Label1.AutoSize = True
+        Me.Label1.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.25!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
+        Me.Label1.Location = New System.Drawing.Point(15, 28)
+        Me.Label1.Name = "Label1"
+        Me.Label1.Size = New System.Drawing.Size(78, 13)
+        Me.Label1.TabIndex = 0
+        Me.Label1.Text = "Server address"
+        '
+        'cmdOK
+        '
+        Me.cmdOK.Location = New System.Drawing.Point(483, 360)
+        Me.cmdOK.Name = "cmdOK"
+        Me.cmdOK.Size = New System.Drawing.Size(75, 23)
+        Me.cmdOK.TabIndex = 8
+        Me.cmdOK.Text = "OK"
+        Me.cmdOK.UseVisualStyleBackColor = True
+        '
+        'frmDatabaseConnections
+        '
+        Me.AutoScaleDimensions = New System.Drawing.SizeF(6.0!, 13.0!)
+        Me.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font
+        Me.ClientSize = New System.Drawing.Size(651, 395)
+        Me.Controls.Add(Me.cmdOK)
+        Me.Controls.Add(Me.grpCurrentSelection)
+        Me.Controls.Add(Me.grpDefaults)
+        Me.Controls.Add(Me.cmdCancel)
+        Me.Controls.Add(Me.DataGridView1)
+        Me.Name = "frmDatabaseConnections"
+        Me.Text = "Database Connections"
+        CType(Me.DataGridView1, System.ComponentModel.ISupportInitialize).EndInit()
+        Me.grpCurrentSelection.ResumeLayout(False)
+        Me.grpDefaults.ResumeLayout(False)
+        Me.grpDefaults.PerformLayout()
+        Me.ResumeLayout(False)
+
+    End Sub
+
+    Friend WithEvents DataGridView1 As DataGridView
+    Friend WithEvents cmdCancel As Button
+    Friend WithEvents connection As DataGridViewTextBoxColumn
+    Friend WithEvents server As DataGridViewTextBoxColumn
+    Friend WithEvents database As DataGridViewTextBoxColumn
+    Friend WithEvents port As DataGridViewTextBoxColumn
+    Friend WithEvents grpCurrentSelection As GroupBox
+    Friend WithEvents cmdTest As Button
+    Friend WithEvents cmdRemove As Button
+    Friend WithEvents grpDefaults As GroupBox
+    Friend WithEvents Label4 As Label
+    Friend WithEvents Label5 As Label
+    Friend WithEvents Label6 As Label
+    Friend WithEvents Label3 As Label
+    Friend WithEvents Label2 As Label
+    Friend WithEvents Label1 As Label
+    Friend WithEvents Label10 As Label
+    Friend WithEvents Label9 As Label
+    Friend WithEvents Label8 As Label
+    Friend WithEvents Label7 As Label
+    Friend WithEvents cmdOK As Button
+    Friend WithEvents cmdMakeDefault As Button
+End Class

--- a/ClimsoftVer4/ClimsoftVer4/frmDatabaseConnections.resx
+++ b/ClimsoftVer4/ClimsoftVer4/frmDatabaseConnections.resx
@@ -1,0 +1,132 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <metadata name="connection.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <metadata name="server.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <metadata name="database.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <metadata name="port.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+</root>

--- a/ClimsoftVer4/ClimsoftVer4/frmDatabaseConnections.vb
+++ b/ClimsoftVer4/ClimsoftVer4/frmDatabaseConnections.vb
@@ -1,0 +1,217 @@
+﻿Public Class frmDatabaseConnections
+
+    Private Sub frmDatabaseConnections_Load(sender As Object, e As EventArgs) Handles MyBase.Load
+        Dim builder As New System.Data.Common.DbConnectionStringBuilder()
+        Dim connection As String
+        Dim connectionString As String
+        Dim key As Microsoft.Win32.RegistryKey
+        Dim result As Integer
+        Dim row As DataGridViewRow
+
+        DataGridView1.Rows.Clear()
+        key = Microsoft.Win32.Registry.LocalMachine.OpenSubKey("Software\\Climsoft4")
+
+        If key IsNot Nothing Then
+            For Each subKey As String In key.GetValueNames
+                If subKey.StartsWith("db_") Then
+                    connectionString = My.Computer.Registry.GetValue(
+                    "HKEY_LOCAL_MACHINE\Software\Climsoft4", subKey, Nothing)
+                    connection = Mid(subKey, 4)
+                    Try
+                        builder.ConnectionString = connectionString
+                        DataGridView1.Rows.Add(connection, builder("server"), builder("database"), builder("port"))
+                    Catch ex As Exception
+                        result = MessageBox.Show(
+                            "Unable to read connection details for """ & connection & """ from the " &
+                            "Windows registry. Would you Like to clear the details for this connection " &
+                            "to resolve the problem (this action cannot be undone)?" &
+                            Environment.NewLine & Environment.NewLine & ex.Message,
+                            "Climsoft Warning", MessageBoxButtons.YesNo)
+                        If result = DialogResult.No Then
+                            Exit Sub
+                        ElseIf result = DialogResult.Yes Then
+                            My.Computer.Registry.LocalMachine.OpenSubKey("SOFTWARE\Climsoft4", True).DeleteValue(
+                                "db_" & connection)
+                        End If
+                    End Try
+                End If
+            Next
+        End If
+    End Sub
+
+    Private Sub cmdOK_Click(sender As Object, e As EventArgs) Handles cmdOK.Click
+        ' In My Project/Compile, make sure that Target CPU is set to "AnyCPU" and uncheck "Prefer 32-bit"
+        ' Otherwise the registry key can get 'redirected', e.g. into SOFTWARE\Wow6432Node
+        Dim builder As New System.Data.Common.DbConnectionStringBuilder()
+        Dim connection As String
+        Dim connectionString As String
+        Dim database As String
+        Dim key As Microsoft.Win32.RegistryKey
+        Dim port As String
+        Dim server As String
+
+        For Each row As DataGridViewRow In DataGridView1.Rows
+            builder = New System.Data.Common.DbConnectionStringBuilder()
+            connection = row.Cells(0).Value
+            server = row.Cells(1).Value
+            database = row.Cells(2).Value
+            port = row.Cells(3).Value
+
+            ' Skip empty rows (and continue to process other rows)
+            If String.IsNullOrEmpty(connection) And String.IsNullOrEmpty(server) And
+                    String.IsNullOrEmpty(database) And String.IsNullOrEmpty(port) Then
+                Continue For
+            End If
+
+            ' Connection name: must not be empty (abort save)
+            If String.IsNullOrEmpty(connection) Then
+                MsgBox("Unable to save connections. Please ensure that each connection has a connection name")
+                Exit Sub
+            End If
+
+            ' Connection name: Match one or more letters, numbers or underscores (otherwise abort save)
+            If Not System.Text.RegularExpressions.Regex.IsMatch(connection, "^[a-zA-Z0-9_]+$") Then
+                MsgBox("Unable to save connection information due to connection """ & connection & """" &
+                       Environment.NewLine & Environment.NewLine &
+                       "The connection name must only contain letters, numbers and underscores")
+                Exit Sub
+            End If
+
+            ' Server address: Match one or more letters, numbers or hyphen or
+            '                 match numbers and period allowing IP addresses (otherwise abort save)
+            If String.IsNullOrEmpty(server) OrElse
+                Not System.Text.RegularExpressions.Regex.IsMatch(server, "^[a-zA-Z0-9-]+$") And
+                Not System.Text.RegularExpressions.Regex.IsMatch(server, "^[0-9.]+$") Then
+
+                MsgBox("Unable to save connection information due to connection """ & connection & """" &
+                       Environment.NewLine & Environment.NewLine &
+                       "The server address must only contain letters, numbers and hyphens (or numbers " &
+                       "and periods for IP addresses, e.g. 127.0.0.1)")
+                Exit Sub
+            End If
+
+            ' Database name: Match one or more letters, numbers or underscores (otherwise abort save)
+            If String.IsNullOrEmpty(database) OrElse
+                Not System.Text.RegularExpressions.Regex.IsMatch(database, "^[a-zA-Z0-9_]+$") Then
+
+                MsgBox("Unable to save connection information due to connection """ & connection & """" &
+                       Environment.NewLine & Environment.NewLine &
+                       "The database name must only contain letters, numbers and underscores")
+                Exit Sub
+            End If
+
+            ' Port number: Match one or more numbers (otherwise abort save)
+            If String.IsNullOrEmpty(port) OrElse
+                Not System.Text.RegularExpressions.Regex.IsMatch(port, "^[0-9]+$") Then
+
+                MsgBox("Unable to save connection information due to connection """ & connection & """" &
+                       Environment.NewLine & Environment.NewLine &
+                       "The port number must be a whole number (e.g. 3306 or 3308)")
+                Exit Sub
+            End If
+        Next
+
+        ' All rows have now been validated remove all existing database connection settings from
+        ' the Windows registry
+        key = Microsoft.Win32.Registry.LocalMachine.OpenSubKey("Software\\Climsoft4")
+
+        If key Is Nothing Then
+            key = Microsoft.Win32.Registry.LocalMachine.CreateSubKey("Software\\Climsoft4")
+        End If
+
+        For Each subKey As String In key.GetValueNames
+            If subKey.StartsWith("db_") Then
+                My.Computer.Registry.LocalMachine.OpenSubKey("SOFTWARE\Climsoft4", True).DeleteValue(subKey)
+            End If
+        Next
+
+        ' Loop over validated rows and add details from each row to the Windows registry
+        For Each row As DataGridViewRow In DataGridView1.Rows
+            builder = New System.Data.Common.DbConnectionStringBuilder()
+            connection = row.Cells(0).Value
+            server = row.Cells(1).Value
+            database = row.Cells(2).Value
+            port = row.Cells(3).Value
+
+            ' Skip empty rows (and continue to save other rows to registry)
+            If String.IsNullOrEmpty(connection) And String.IsNullOrEmpty(server) And
+                String.IsNullOrEmpty(database) And String.IsNullOrEmpty(port) Then
+                Continue For
+            End If
+
+            connectionString = "server=" & server & ";database=" & database & ";port=" & port
+
+            ' Check that the connection string is accepted by the connection string builder (otherwise warn)
+            Try
+                builder.ConnectionString = connectionString
+            Catch ex As Exception
+                MsgBox("Unable to save connection information for connection """ & connection & """" &
+                    Environment.NewLine & Environment.NewLine & ex.Message)
+                Continue For
+            End Try
+
+            ' Only save to registry if the built connection string is not null/empty
+            ' All connection names will have a prefix "db_"
+            If Not String.IsNullOrEmpty(builder.ConnectionString) Then
+                key = Microsoft.Win32.Registry.LocalMachine.CreateSubKey("Software\\Climsoft4")
+                key.SetValue("db_" & connection, connectionString)
+            End If
+        Next
+
+        frmLogin.refreshDatabases()
+        Close()
+    End Sub
+
+    Private Sub cmdCancel_Click(sender As Object, e As EventArgs) Handles cmdCancel.Click
+        Close()
+    End Sub
+
+    Private Sub DataGridView1_SelectionChanged(sender As Object, e As EventArgs) Handles DataGridView1.SelectionChanged
+        Try
+            If DataGridView1.CurrentCell.RowIndex + 1 = DataGridView1.Rows.Count Then
+                grpCurrentSelection.Enabled = False
+            Else
+                grpCurrentSelection.Enabled = True
+            End If
+        Catch ex As Exception
+
+        End Try
+    End Sub
+
+    Private Sub cmdMakeDefault_Click(sender As Object, e As EventArgs) Handles cmdMakeDefault.Click
+        Dim colIndex As Integer
+        Dim row As DataGridViewRow
+        Try
+            colIndex = DataGridView1.SelectedCells(0).OwningColumn.Index
+            row = DataGridView1.Rows(DataGridView1.CurrentCell.RowIndex)
+            DataGridView1.Rows.Remove(row)
+            DataGridView1.Rows.Insert(0, row)
+            DataGridView1.Refresh()
+            DataGridView1.ClearSelection()
+            DataGridView1.Rows(0).Cells(colIndex).Selected = True
+        Catch ex As Exception
+
+        End Try
+
+
+        '        List<MyObj> foo = DGV.DataSource;
+        'Int idx = DGV.SelectedRows[0].Index;
+        'Int value = foo[idx];
+        'foo.Remove(value);
+        'foo.InsertAt(idx+1, value)
+    End Sub
+
+    Private Sub cmdTest_Click(sender As Object, e As EventArgs) Handles cmdTest.Click
+
+    End Sub
+
+    Private Sub cmdRemove_Click(sender As Object, e As EventArgs) Handles cmdRemove.Click
+        Try
+            DataGridView1.Rows.RemoveAt(DataGridView1.CurrentCell.RowIndex)
+            DataGridView1.Refresh()
+        Catch ex As Exception
+
+        End Try
+    End Sub
+
+End Class

--- a/ClimsoftVer4/ClimsoftVer4/frmLogin.Designer.vb
+++ b/ClimsoftVer4/ClimsoftVer4/frmLogin.Designer.vb
@@ -40,10 +40,12 @@ Partial Class frmLogin
         Me.OK = New System.Windows.Forms.Button()
         Me.Cancel = New System.Windows.Forms.Button()
         Me.txtusrpwd = New System.Windows.Forms.TextBox()
+        Me.cmdHelp = New System.Windows.Forms.Button()
         Me.cmbDatabases = New System.Windows.Forms.ComboBox()
         Me.lblDbdetails = New System.Windows.Forms.Label()
-        Me.cmdHelp = New System.Windows.Forms.Button()
         Me.BindingSource1 = New System.Windows.Forms.BindingSource(Me.components)
+        Me.Label1 = New System.Windows.Forms.Label()
+        Me.chkRememberUsername = New System.Windows.Forms.CheckBox()
         CType(Me.LogoPictureBox, System.ComponentModel.ISupportInitialize).BeginInit()
         CType(Me.BindingSource1, System.ComponentModel.ISupportInitialize).BeginInit()
         Me.SuspendLayout()
@@ -54,7 +56,7 @@ Partial Class frmLogin
         Me.LogoPictureBox.Image = CType(resources.GetObject("LogoPictureBox.Image"), System.Drawing.Image)
         Me.LogoPictureBox.Location = New System.Drawing.Point(0, 0)
         Me.LogoPictureBox.Name = "LogoPictureBox"
-        Me.LogoPictureBox.Size = New System.Drawing.Size(178, 224)
+        Me.LogoPictureBox.Size = New System.Drawing.Size(199, 251)
         Me.LogoPictureBox.SizeMode = System.Windows.Forms.PictureBoxSizeMode.StretchImage
         Me.LogoPictureBox.TabIndex = 0
         Me.LogoPictureBox.TabStop = False
@@ -62,7 +64,7 @@ Partial Class frmLogin
         'lblUsername
         '
         Me.lblUsername.AutoSize = True
-        Me.lblUsername.Location = New System.Drawing.Point(192, 19)
+        Me.lblUsername.Location = New System.Drawing.Point(218, 11)
         Me.lblUsername.Name = "lblUsername"
         Me.lblUsername.Size = New System.Drawing.Size(55, 13)
         Me.lblUsername.TabIndex = 0
@@ -73,7 +75,7 @@ Partial Class frmLogin
         'lblPassword
         '
         Me.lblPassword.AutoSize = True
-        Me.lblPassword.Location = New System.Drawing.Point(192, 76)
+        Me.lblPassword.Location = New System.Drawing.Point(218, 61)
         Me.lblPassword.Name = "lblPassword"
         Me.lblPassword.Size = New System.Drawing.Size(53, 13)
         Me.lblPassword.TabIndex = 2
@@ -83,7 +85,7 @@ Partial Class frmLogin
         '
         'txtUsername
         '
-        Me.txtUsername.Location = New System.Drawing.Point(194, 39)
+        Me.txtUsername.Location = New System.Drawing.Point(220, 31)
         Me.txtUsername.Name = "txtUsername"
         Me.txtUsername.Size = New System.Drawing.Size(220, 20)
         Me.txtUsername.TabIndex = 1
@@ -91,7 +93,7 @@ Partial Class frmLogin
         '
         'txtPassword
         '
-        Me.txtPassword.Location = New System.Drawing.Point(194, 96)
+        Me.txtPassword.Location = New System.Drawing.Point(220, 81)
         Me.txtPassword.Name = "txtPassword"
         Me.txtPassword.PasswordChar = Global.Microsoft.VisualBasic.ChrW(42)
         Me.txtPassword.Size = New System.Drawing.Size(220, 20)
@@ -100,7 +102,7 @@ Partial Class frmLogin
         '
         'OK
         '
-        Me.OK.Location = New System.Drawing.Point(239, 187)
+        Me.OK.Location = New System.Drawing.Point(239, 219)
         Me.OK.Name = "OK"
         Me.OK.Size = New System.Drawing.Size(67, 23)
         Me.OK.TabIndex = 4
@@ -110,7 +112,7 @@ Partial Class frmLogin
         'Cancel
         '
         Me.Cancel.DialogResult = System.Windows.Forms.DialogResult.Cancel
-        Me.Cancel.Location = New System.Drawing.Point(342, 187)
+        Me.Cancel.Location = New System.Drawing.Point(342, 219)
         Me.Cancel.Name = "Cancel"
         Me.Cancel.Size = New System.Drawing.Size(67, 23)
         Me.Cancel.TabIndex = 5
@@ -119,42 +121,63 @@ Partial Class frmLogin
         '
         'txtusrpwd
         '
-        Me.txtusrpwd.Location = New System.Drawing.Point(197, 40)
+        Me.txtusrpwd.Location = New System.Drawing.Point(223, 32)
         Me.txtusrpwd.Name = "txtusrpwd"
         Me.txtusrpwd.Size = New System.Drawing.Size(177, 20)
         Me.txtusrpwd.TabIndex = 6
         Me.txtusrpwd.Visible = False
         '
-        'cmbDatabases
-        '
-        Me.cmbDatabases.BackColor = System.Drawing.SystemColors.Menu
-        Me.cmbDatabases.FormattingEnabled = True
-        Me.cmbDatabases.Location = New System.Drawing.Point(194, 143)
-        Me.cmbDatabases.Name = "cmbDatabases"
-        Me.cmbDatabases.Size = New System.Drawing.Size(333, 21)
-        Me.cmbDatabases.TabIndex = 7
-        Me.cmbDatabases.Visible = False
-        '
-        'lblDbdetails
-        '
-        Me.lblDbdetails.AutoSize = True
-        Me.lblDbdetails.ForeColor = System.Drawing.Color.Blue
-        Me.lblDbdetails.Location = New System.Drawing.Point(192, 129)
-        Me.lblDbdetails.Name = "lblDbdetails"
-        Me.lblDbdetails.Size = New System.Drawing.Size(233, 13)
-        Me.lblDbdetails.TabIndex = 8
-        Me.lblDbdetails.Tag = "Show_and_Configure_Database_Connection"
-        Me.lblDbdetails.Text = "Show and Configure Database Connection........"
-        '
         'cmdHelp
         '
         Me.cmdHelp.DialogResult = System.Windows.Forms.DialogResult.Cancel
-        Me.cmdHelp.Location = New System.Drawing.Point(445, 187)
+        Me.cmdHelp.Location = New System.Drawing.Point(445, 219)
         Me.cmdHelp.Name = "cmdHelp"
         Me.cmdHelp.Size = New System.Drawing.Size(67, 23)
         Me.cmdHelp.TabIndex = 9
         Me.cmdHelp.Tag = "Help"
         Me.cmdHelp.Text = "&Help"
+        Me.cmdHelp.Visible = False
+        '
+        'cmbDatabases
+        '
+        Me.cmbDatabases.BackColor = System.Drawing.SystemColors.Menu
+        Me.cmbDatabases.FormattingEnabled = True
+        Me.cmbDatabases.Location = New System.Drawing.Point(218, 162)
+        Me.cmbDatabases.Name = "cmbDatabases"
+        Me.cmbDatabases.Size = New System.Drawing.Size(222, 21)
+        Me.cmbDatabases.TabIndex = 7
+        '
+        'lblDbdetails
+        '
+        Me.lblDbdetails.AutoSize = True
+        Me.lblDbdetails.ForeColor = System.Drawing.Color.Blue
+        Me.lblDbdetails.Location = New System.Drawing.Point(218, 187)
+        Me.lblDbdetails.Name = "lblDbdetails"
+        Me.lblDbdetails.Size = New System.Drawing.Size(154, 13)
+        Me.lblDbdetails.TabIndex = 8
+        Me.lblDbdetails.Tag = ""
+        Me.lblDbdetails.Text = "Manage database connections"
+        '
+        'Label1
+        '
+        Me.Label1.AutoSize = True
+        Me.Label1.Location = New System.Drawing.Point(218, 142)
+        Me.Label1.Name = "Label1"
+        Me.Label1.Size = New System.Drawing.Size(53, 13)
+        Me.Label1.TabIndex = 10
+        Me.Label1.Tag = "Password"
+        Me.Label1.Text = "&Database"
+        Me.Label1.TextAlign = System.Drawing.ContentAlignment.MiddleLeft
+        '
+        'chkRememberUsername
+        '
+        Me.chkRememberUsername.AutoSize = True
+        Me.chkRememberUsername.Location = New System.Drawing.Point(220, 113)
+        Me.chkRememberUsername.Name = "chkRememberUsername"
+        Me.chkRememberUsername.Size = New System.Drawing.Size(126, 17)
+        Me.chkRememberUsername.TabIndex = 11
+        Me.chkRememberUsername.Text = "Remember username"
+        Me.chkRememberUsername.UseVisualStyleBackColor = True
         '
         'frmLogin
         '
@@ -162,7 +185,9 @@ Partial Class frmLogin
         Me.AutoScaleDimensions = New System.Drawing.SizeF(6.0!, 13.0!)
         Me.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font
         Me.CancelButton = Me.Cancel
-        Me.ClientSize = New System.Drawing.Size(539, 222)
+        Me.ClientSize = New System.Drawing.Size(539, 251)
+        Me.Controls.Add(Me.chkRememberUsername)
+        Me.Controls.Add(Me.Label1)
         Me.Controls.Add(Me.cmdHelp)
         Me.Controls.Add(Me.lblDbdetails)
         Me.Controls.Add(Me.cmbDatabases)
@@ -189,8 +214,10 @@ Partial Class frmLogin
 
     End Sub
     Friend WithEvents txtusrpwd As System.Windows.Forms.TextBox
-    Friend WithEvents cmbDatabases As System.Windows.Forms.ComboBox
-    Friend WithEvents lblDbdetails As System.Windows.Forms.Label
     Friend WithEvents cmdHelp As System.Windows.Forms.Button
     Friend WithEvents BindingSource1 As BindingSource
+    Friend WithEvents cmbDatabases As ComboBox
+    Friend WithEvents lblDbdetails As Label
+    Friend WithEvents Label1 As Label
+    Friend WithEvents chkRememberUsername As CheckBox
 End Class

--- a/ClimsoftVer4/ClimsoftVer4/frmLogin.vb
+++ b/ClimsoftVer4/ClimsoftVer4/frmLogin.vb
@@ -20,94 +20,100 @@ Imports ClimsoftVer4.Translations
 Public Class frmLogin
     Public HTMLHelp As New clsHelp
     Dim conn As New MySql.Data.MySqlClient.MySqlConnection
-    Dim line As String
-
-    Dim sr As IO.StreamReader
-
-
-    ' TODO: Insert code to perform custom authentication using the provided username and password 
-    ' (See http://go.microsoft.com/fwlink/?LinkId=35339).  
-    ' The custom principal can then be attached to the current thread's principal as follows: 
-    '     My.User.CurrentPrincipal = CustomPrincipal
-    ' where CustomPrincipal is the IPrincipal implementation used to perform authentication. 
-    ' Subsequently, My.User will return identity information encapsulated in the CustomPrincipal object
-    ' such as the username, display name, etc.
 
     Private Sub OK_Click(ByVal sender As System.Object, ByVal e As System.EventArgs) Handles OK.Click
-        ConfigFile()
-        'frmMainMenu.Show()
-        'Me.Hide()
-        'regDataInit()
+        Dim builder As New System.Data.Common.DbConnectionStringBuilder()
+        Dim connectionString As String
+        Dim dbChoice As String
+        Dim password As String
+        Dim subKey As String
+        Dim username As String
+
+        username = txtUsername.Text
+        password = txtPassword.Text
+
+        ' Ensure username and password are not empty
+        If String.IsNullOrEmpty(username) Or String.IsNullOrEmpty(password) Then
+            MsgBox("Please enter a username and password")
+            Exit Sub
+        End If
+
+        updateRememberedUsername()
+
+        dbChoice = cmbDatabases.SelectedItem
+        If String.IsNullOrEmpty(dbChoice) Then
+            MsgBox("Please select a database from the list, or manage database connections")
+            Exit Sub
+        Else
+            subKey = "db_" & dbChoice
+            connectionString = My.Computer.Registry.GetValue(
+                    "HKEY_LOCAL_MACHINE\Software\Climsoft4", subKey, Nothing)
+            If String.IsNullOrEmpty(connectionString) Then
+                MsgBox("Unable to read connection information. Please select ""Manage database connections"" " &
+                       "to check and amend connection details")
+                Exit Sub
+            End If
+        End If
+
+        ' Check that the connection string, with username and password is accepted by the
+        ' connection String builder (otherwise warn and stop)
+        Try
+            builder.ConnectionString = connectionString
+            builder("uid") = username
+            builder("pwd") = password
+
+            ' The connection string has historically been stored in this control
+            ' There are other locations in the software that may access this
+            txtusrpwd.Text = builder.ConnectionString & ";Convert Zero Datetime=True"
+        Catch ex As Exception
+            MsgBox("Login failed: " & ex.Message)
+        End Try
+
+        conn.ConnectionString = txtusrpwd.Text
+        Try
+            conn.Open()
+        Catch ex As Exception
+            If ex.Message.IndexOf("Access denied for user") >= 0 Then
+                MsgBox("Access denied. Please try again.")
+                ' Move cursor to password box and clear password to encourage the user to try again
+                txtPassword.Text = ""
+                txtPassword.Select()
+            ElseIf ex.Message.IndexOf("Unable to connect") >= 0 Then
+                MsgBox("Unable to connect to database, please test database connection using " &
+                       """Manage database connections""")
+            Else
+                MsgBox("Login failed: " & ex.Message)
+            End If
+
+            Exit Sub
+        End Try
+
+        regDataInit()
+        languageTableInit()
+        clsDataConnection.OpenConnection()
+        climsoftuserRoles()
+        frmSplashScreen.Show()
+        Me.Hide()
     End Sub
 
     Private Sub Cancel_Click(ByVal sender As System.Object, ByVal e As System.EventArgs) Handles Cancel.Click
         Me.Close()
     End Sub
 
-    Sub ConfigFile()
-        Try
-
-            ' Create an instance of StreamReader to read from a file. 
-            ' Then open the configuration file
-            'MsgBox(Application.StartupPath.Replace("\bin\Debug", "\config.inf"))
-            'Using sr As New System.IO.StreamReader(Application.StartupPath.Replace("\bin\Debug", "\config.inf"))
-
-            ' Dim line As String
-            Dim connectstr As String
-            Dim caption As String
-
-            ' Read from the configuration file
-            'line = sr.ReadLine()
-
-            'MsgBox(Server_db_port(line))
-
-            ' Contruct the connection string using the output the file
-
-            If cmbDatabases.Text <> "" Then line = cmbDatabases.Text ' Change the connection string to the selected database
-
-            'Added Convert Zero Datetime=True" to connection string to resolve error message _
-            '"Unable to convert MySQL date/time value to System.DateTime ASM 20160124"
-            connectstr = line & "uid=" & txtUsername.Text & ";pwd=" & txtPassword.Text & ";Convert Zero Datetime=True"
-
-            'MsgBox(connectstr)
-            txtusrpwd.Text = connectstr
-            conn.ConnectionString = connectstr 'line
-            conn.Open()
-            sr.Close()
-            ' Load Splash screen
-            caption = Mid(line, 1, Len(line) - 11)
-
-            frmMainMenu.Text = frmMainMenu.Text & "          ...           " & caption
-            frmSplashScreen.Show()
-            Me.Hide()
-            ' End Using
-            regDataInit()
-
-            languageTableInit()
-            climsoftuserRoles()
-
-            clsDataConnection.OpenConnection()
-            conn.Close()
-
-        Catch e As Exception
-            'MsgBox("Login failure")
-            MsgBox(e.Message, MsgBoxStyle.Exclamation)
-            conn.Close()
-        End Try
-    End Sub
     Sub climsoftuserRoles()
         'Set SQL for populating user roles
         rolesSQL = "SELECT * from climsoftusers"
         daClimsoftUserRoles = New MySql.Data.MySqlClient.MySqlDataAdapter(rolesSQL, conn)
         daClimsoftUserRoles.Fill(dsClimsoftUserRoles, "userRoles")
     End Sub
+
     Sub languageTableInit()
         'Set SQL string for populating "regData" dataset
         languageTableSQL = "SELECT * from language_translation"     '
         daLanguageTable = New MySql.Data.MySqlClient.MySqlDataAdapter(languageTableSQL, conn)
         daLanguageTable.Fill(dsLanguageTable, "languageTranslation")
     End Sub
-    
+
     Sub regDataInit()
         'Set SQL string for populating "regData" dataset
         regSQL = "SELECT keyName,keyValue FROM regkeys"     '
@@ -115,30 +121,38 @@ Public Class frmLogin
         daReg.Fill(dsReg, "regData")
     End Sub
 
-    ' End Module
-    Sub Server_db_port(svrdbstr As String)
-        Dim Ssvr, Esvr, Sdb, Edb As Integer
-        Dim Svr_db_port, svrstr, dbstr, portstr As String
-        ' server=127.0.0.1;database=mysql_climsoft_db_v4;port=3306;
-        Ssvr = 8
-        Esvr = InStr(svrdbstr, ";database=")
-        Sdb = Esvr + 10
-        Edb = InStr(svrdbstr, ";port")
-        portstr = Mid(svrdbstr, Edb + 6, 4)
-        svrstr = Mid(svrdbstr, Ssvr, Esvr - Ssvr)
-        dbstr = Mid(svrdbstr, Sdb, Edb - Sdb)
-        Svr_db_port = svrstr & "\\" & dbstr
-        'MsgBox(svrstr & " " & dbstr & " " & portstr)
-        frmLaunchPad.txtServer.Text = svrstr
-        frmLaunchPad.txtDatabase.Text = dbstr
-        frmLaunchPad.txtPort.Text = portstr
-        frmLaunchPad.Show()
-        frmLaunchPad.lblConection.Text = svrdbstr & "uid=" & txtUsername.Text & ";pwd=" & txtPassword.Text & ";Convert Zero Datetime=True"
-
+    Sub updateRememberedUsername()
+        ' Check whether the username should be saved for next time and update accordingly
+        If chkRememberUsername.Checked Then
+            My.Settings.rememberUsername = True
+            My.Settings.rememberedUsername = txtUsername.Text
+        Else
+            My.Settings.rememberUsername = False
+            My.Settings.rememberedUsername = ""
+        End If
+        My.Settings.Save()
     End Sub
-    'Private Sub LoginForm_Load(sender As Object, e As EventArgs) Handles MyBase.Load
 
-    'End Sub
+    Sub refreshDatabases()
+        Dim connection As String
+        Dim key As Microsoft.Win32.RegistryKey
+        Dim remember_username As String
+        Dim username As String
+
+        ' Clear and then populate Database combobox
+        cmbDatabases.Items.Clear()
+        key = Microsoft.Win32.Registry.LocalMachine.OpenSubKey("Software\\Climsoft4")
+
+        If key IsNot Nothing Then
+            For Each subKey As String In key.GetValueNames
+                If subKey.StartsWith("db_") Then
+                    connection = Mid(subKey, 4)
+                    cmbDatabases.Items.Add(connection)
+                End If
+            Next
+            cmbDatabases.SelectedIndex = 0
+        End If
+    End Sub
 
     Private Sub LoginForm_Load(sender As Object, e As EventArgs) Handles Me.Load
         '-------Code for translation added 20160207,ASM
@@ -146,80 +160,63 @@ Public Class frmLogin
         'Other Translation after successful login will come from language translation table stored in database
 
         msgKeyentryFormsListUpdated = "List of key-entry forms updated!"
-        msgStationInformationNotFound = "Station information not found. Please add station information and try again!"
+        msgStationInformationNotFound = "Station information Not found. Please add station information And try again!"
 
         Dim lanCulture As String
         lanCulture = System.Globalization.CultureInfo.CurrentCulture.Name
         If Strings.Left(lanCulture, 2) = "en" Then
-            ' MsgBox("Current language is: English-UK")
+            ' MsgBox("Current language Is: English-UK")
             Me.Text = "Login"
             lblUsername.Text = "User name:"
             lblPassword.Text = "Password:"
-            lblDbdetails.Text = "Show and Configure Database Connection....."
+            'lblDbdetails.Text = "Show and Configure Database Connection....."
             OK.Text = "OK"
             Cancel.Text = "Cancel"
         ElseIf Strings.Left(lanCulture, 2) = "fr" Then
             Me.Text = "s'identifier"
             lblUsername.Text = "Nom d'utilisateur:"
             lblPassword.Text = "Mot de passe:"
-            lblDbdetails.Text = "Afficher et configurer la base de données de connexion....."
+            'lblDbdetails.Text = "Afficher et configurer la base de données de connexion....."
             OK.Text = "OK"
             Cancel.Text = "Annuler"
         ElseIf Strings.Left(lanCulture, 2) = "de" Then
             Me.Text = "Anmeldung"
             lblUsername.Text = "Benutzername:"
             lblPassword.Text = "Passwort:"
-            lblDbdetails.Text = "Anzeige und Konfiguration der Verbindungsdatenbank....."
+            'lblDbdetails.Text = "Anzeige und Konfiguration der Verbindungsdatenbank....."
             OK.Text = "OK"
             Cancel.Text = "Stornieren"
         ElseIf Strings.Left(lanCulture, 2) = "pt" Then
             Me.Text = "Entrar"
             lblUsername.Text = "Nome de usuário:"
             lblPassword.Text = "Senha:"
-            lblDbdetails.Text = "Mostrar e configurar o banco de dados de conexão....."
+            'lblDbdetails.Text = "Mostrar e configurar o banco de dados de conexão....."
             OK.Text = "OK"
             Cancel.Text = "Cancelar"
         End If
-        '------------------
-        ' If the user's machine is set to an alternative language then this alternative will be used if available
-        'autoTranslate(Me)
 
-        Try
-            sr = New IO.StreamReader("config.inf")
-        Catch ex As Exception
-            If TypeOf ex Is System.IO.FileNotFoundException Then
+        If My.Settings.rememberUsername Then
+            chkRememberUsername.Checked = True
+            txtUsername.Text = My.Settings.rememberedUsername
+            ' When loading, we have to show the form before we can give password the focus
+            Me.Show()
+            txtPassword.Focus()
+        End If
 
-                ' TODO: Log warning: "A required CLIMSOFT configuration file is missing. " & ex.Message
-                ' Try to recover by using the default settings:
-                ' My.MySettings.Default.defaultDatabase
-            Else
-
-                Throw
-            End If
-        End Try
-
-        line = sr.ReadLine()
-        'MsgBox(line)
-        cmbDatabases.Items.Add(line)
-
-        cmbDatabases.Text = cmbDatabases.Items.Item(0)
-        'MsgBox(cmbDatabases.Text)
-        sr.Close()
-
+        refreshDatabases()
     End Sub
 
+    Private Sub LoginForm_FormClosing(ByVal sender As Object, ByVal e As System.Windows.Forms.FormClosingEventArgs) Handles Me.FormClosing
+        updateRememberedUsername()
+    End Sub
 
     Private Sub lblDbdetails_Click(sender As Object, e As EventArgs) Handles lblDbdetails.Click
-        If lblDbdetails.Text = "Show and Configure Database Connection........" Then
-            'cmbDatabases.Visible = True
-            'sr.Close()
-            line = cmbDatabases.Text
-            Server_db_port(line)
-            'lblDbdetails.Text = "Hide Database Details........"
+        If Not My.User.IsInRole(ApplicationServices.BuiltInRole.Administrator) Then
+            MsgBox("You must be an Administrator in order to manage database connections. When starting the program, right-click on the Climsoft icon and choose ""Run as administrator""")
+            ' It's useful to refresh the databases here so that you don't need to restart if reg has been updated externally
+            refreshDatabases()
         Else
-            frmLaunchPad.Close()
-            cmbDatabases.Visible = False
-            lblDbdetails.Text = "Show and Configure Database Connection........"
+            frmDatabaseConnections.ShowDialog()
         End If
     End Sub
 
@@ -233,9 +230,14 @@ Public Class frmLogin
     End Sub
 
     Private Sub cmdHelp_Click(sender As Object, e As EventArgs) Handles cmdHelp.Click
-        'HTMLHelp.HelpPage = "login.htm"
-        'Help.ShowHelp(Me, Application.StartupPath & "\" & HelpProvider1.HelpNamespace, HTMLHelp.HelpPage)
         Help.ShowHelp(Me, Application.StartupPath & "\climsoft4.chm", "login.htm")
+    End Sub
 
+    Private Sub chkRememberUsername_CheckedChanged(sender As Object, e As EventArgs) Handles chkRememberUsername.CheckedChanged
+        If Not chkRememberUsername.Checked Then
+            My.Settings.rememberUsername = False
+            My.Settings.rememberedUsername = ""
+            My.Settings.Save()
+        End If
     End Sub
 End Class

--- a/ClimsoftVer4/ClimsoftVer4/frmMainMenu.Designer.vb
+++ b/ClimsoftVer4/ClimsoftVer4/frmMainMenu.Designer.vb
@@ -37,7 +37,6 @@ Partial Class frmMainMenu
         Me.PasswordToolStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
         Me.DataFormsToolStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
         Me.UpdateElementsToolStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
-        Me.ConfigureDatabaseConnectionToolStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
         Me.UpdateObservationsToolStripMenuItem1 = New System.Windows.Forms.ToolStripMenuItem()
         Me.OpeartionsMonitoringToolStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
         Me.EmptyKeyEntryTablesToolStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
@@ -165,7 +164,7 @@ Partial Class frmMainMenu
         '
         'mnuAdministration
         '
-        Me.mnuAdministration.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.UserAdminToolStripMenuItem, Me.MetadataToolStripMenuItem, Me.PasswordToolStripMenuItem, Me.DataFormsToolStripMenuItem, Me.UpdateElementsToolStripMenuItem, Me.ConfigureDatabaseConnectionToolStripMenuItem, Me.UpdateObservationsToolStripMenuItem1, Me.OpeartionsMonitoringToolStripMenuItem, Me.EmptyKeyEntryTablesToolStripMenuItem})
+        Me.mnuAdministration.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.UserAdminToolStripMenuItem, Me.MetadataToolStripMenuItem, Me.PasswordToolStripMenuItem, Me.DataFormsToolStripMenuItem, Me.UpdateElementsToolStripMenuItem, Me.UpdateObservationsToolStripMenuItem1, Me.OpeartionsMonitoringToolStripMenuItem, Me.EmptyKeyEntryTablesToolStripMenuItem})
         Me.mnuAdministration.Name = "mnuAdministration"
         Me.mnuAdministration.Size = New System.Drawing.Size(111, 23)
         Me.mnuAdministration.Tag = "Administration"
@@ -205,12 +204,6 @@ Partial Class frmMainMenu
         Me.UpdateElementsToolStripMenuItem.Tag = "Update_Element_Limits"
         Me.UpdateElementsToolStripMenuItem.Text = "Update Element Limits"
         Me.UpdateElementsToolStripMenuItem.Visible = False
-        '
-        'ConfigureDatabaseConnectionToolStripMenuItem
-        '
-        Me.ConfigureDatabaseConnectionToolStripMenuItem.Name = "ConfigureDatabaseConnectionToolStripMenuItem"
-        Me.ConfigureDatabaseConnectionToolStripMenuItem.Size = New System.Drawing.Size(273, 24)
-        Me.ConfigureDatabaseConnectionToolStripMenuItem.Text = "Configure Database Connection"
         '
         'UpdateObservationsToolStripMenuItem1
         '
@@ -715,7 +708,6 @@ Partial Class frmMainMenu
     Friend WithEvents DailyToolStripMenuItem As System.Windows.Forms.ToolStripMenuItem
     Friend WithEvents FormHourlyTimeSelectionToolStripMenuItem As System.Windows.Forms.ToolStripMenuItem
     Friend WithEvents ChangeOwnPasswordToolStripMenuItem As System.Windows.Forms.ToolStripMenuItem
-    Friend WithEvents ConfigureDatabaseConnectionToolStripMenuItem As System.Windows.Forms.ToolStripMenuItem
     Friend WithEvents mnuLanguageTranslation As System.Windows.Forms.ToolStripMenuItem
     Friend WithEvents AWSToolStripMenuItem As System.Windows.Forms.ToolStripMenuItem
     Friend WithEvents AWSElementsToolStripMenuItem As System.Windows.Forms.ToolStripMenuItem

--- a/ClimsoftVer4/ClimsoftVer4/frmMainMenu.vb
+++ b/ClimsoftVer4/ClimsoftVer4/frmMainMenu.vb
@@ -247,15 +247,11 @@ Public Class frmMainMenu
         frmChangeOwnPassword.Show()
     End Sub
 
-    Private Sub ConfigureDatabaseConnectionToolStripMenuItem_Click(sender As Object, e As EventArgs) Handles ConfigureDatabaseConnectionToolStripMenuItem.Click
-        frmLogin.Server_db_port(frmLogin.cmbDatabases.Text)
-    End Sub
-
     Private Sub mnuTools_Click(sender As Object, e As EventArgs) Handles mnuTools.Click
 
     End Sub
 
-    
+
     Private Sub mnuLanguageTranslation_Click(sender As Object, e As EventArgs) Handles mnuLanguageTranslation.Click
         frmLanguageTranslation.Show()
     End Sub


### PR DESCRIPTION
The user can now select which database they want to connect to from a dropdown list that contains the names of all available database connections.

![login](https://user-images.githubusercontent.com/2097922/59336672-e565ac80-8cf6-11e9-8ed8-d4bbd3e34420.PNG)

Users can click on "Manage database connections".  If they are not a Windows Administrator then they see the following message:

![admin](https://user-images.githubusercontent.com/2097922/59338025-87869400-8cf9-11e9-9c43-eb0eabac5df8.png)

Database connections are edited in a grid view. When the users clicks okay, the connection details are stored in the Windows Registry under `Computer\HKEY_LOCAL_MACHINE\SOFTWARE\Climsoft4`. This ensures that the connection details are still available when the software is updated to a new version.

![db_connections](https://user-images.githubusercontent.com/2097922/59338152-c0bf0400-8cf9-11e9-810e-25511ece132d.PNG)